### PR TITLE
Deployment changes to support Druid Basic Auth configurations

### DIFF
--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -200,6 +200,9 @@ module "dataset_api" {
   redis_release_name                 = module.redis.redis_release_name
   dataset_api_namespace              = module.eks.dataset_api_namespace
   s3_bucket                          = module.s3.s3_bucket
+  druid_admin_password               = var.druid_admin_password
+  druid_auth_enabled                 = var.druid_auth_enabled
+  druid_admin_username               = var.druid_admin_username
 }
 
 module "secor" {
@@ -220,6 +223,9 @@ module "submit_ingestion" {
   submit_ingestion_chart_depends_on = [module.kafka, module.druid_raw_cluster]
   druid_cluster_release_name        = module.druid_raw_cluster.druid_cluster_release_name
   druid_cluster_namespace           = module.druid_raw_cluster.druid_cluster_namespace
+  druid_auth_enabled                = var.druid_auth_enabled
+  druid_admin_username              = var.druid_admin_username
+  druid_admin_password              = var.druid_admin_password
 }
 
 module "velero" {

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -152,6 +152,8 @@ module "druid_raw_cluster" {
   druid_raw_user_password            = module.postgresql.postgresql_druid_raw_user_password
   druid_raw_sa_annotations           = "eks.amazonaws.com/role-arn: ${module.eks.druid_raw_sa_iam_role}"
   druid_cluster_namespace            = module.eks.druid_raw_namespace
+  druid_admin_password               = var.druid_admin_password
+  druid_auth_enabled                 = var.druid_auth_enabled
 }
 
 module "druid_operator" {

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -125,6 +125,12 @@ variable "druid_auth_enabled" {
   default     = true
 }
 
+variable "druid_admin_username" {
+  type        = string
+  description = "name of druid initial admin user"
+  default     = "admin"
+}
+
 variable "druid_admin_password" {
   type        = string
   description = "Password for druid initial admin user"

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -118,3 +118,15 @@ variable "command_service_image_tag" {
   description = "CommandService image tag."
   default     = "1.0.0"
 }
+
+variable "druid_auth_enabled" {
+  type        = bool
+  description = "Toggle to enable/disable druid basic auth"
+  default     = true
+}
+
+variable "druid_admin_password" {
+  type        = string
+  description = "Password for druid initial admin user"
+  default     = "admin"
+}

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -160,6 +160,9 @@ module "dataset_api" {
   dataset_api_postgres_user_password = module.postgresql.postgresql_dataset_api_user_password
   dataset_api_sa_annotations         = "this-needs-to: be-implemented-and-added"
   dataset_api_chart_depends_on       = [module.postgresql, module.kafka]
+  druid_admin_password               = var.druid_admin_password
+  druid_auth_enabled                 = var.druid_auth_enabled
+  druid_admin_username               = var.druid_admin_username
 }
 
 module "secor" {
@@ -174,6 +177,9 @@ module "submit_ingestion" {
   env                               = var.env
   building_block                    = var.building_block
   submit_ingestion_chart_depends_on = [module.kafka, module.druid_raw_cluster]
+  druid_auth_enabled                = var.druid_auth_enabled
+  druid_admin_username              = var.druid_admin_username
+  druid_admin_password              = var.druid_admin_password
 }
 
 module "alert_rules" {

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -119,6 +119,8 @@ module "druid_raw_cluster" {
   druid_raw_cluster_chart_depends_on = [module.postgresql, module.druid_operator]
   kubernetes_storage_class           = var.kubernetes_storage_class
   druid_raw_user_password            = module.postgresql.postgresql_druid_raw_user_password
+  druid_admin_password               = var.druid_admin_password
+  druid_auth_enabled                 = var.druid_auth_enabled
 }
 
 module "druid_operator" {

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -57,3 +57,15 @@ variable "command_service_image_tag" {
   description = "CommandService image tag."
   default     = "1.0.0"
 }
+
+variable "druid_auth_enabled" {
+  type        = bool
+  description = "Toggle to enable/disable druid basic auth"
+  default     = true
+}
+
+variable "druid_admin_password" {
+  type        = string
+  description = "Password for druid initial admin user"
+  default     = "admin"
+}

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -64,6 +64,12 @@ variable "druid_auth_enabled" {
   default     = true
 }
 
+variable "druid_admin_username" {
+  type        = string
+  description = "name of druid initial admin user"
+  default     = "admin"
+}
+
 variable "druid_admin_password" {
   type        = string
   description = "Password for druid initial admin user"

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -431,6 +431,9 @@ module "dataset_api" {
   redis_release_name                 = module.redis.redis_release_name
   dataset_api_namespace              = var.dataset_api_namespace
   depends_on                         = [ module.dataset_api_sa_iam_role ]
+  druid_admin_password               = var.druid_admin_password
+  druid_auth_enabled                 = var.druid_auth_enabled
+  druid_admin_username               = var.druid_admin_username
 }
 
 module "secor" {
@@ -452,6 +455,9 @@ module "submit_ingestion" {
   env                               = var.env
   building_block                    = var.building_block
   submit_ingestion_chart_depends_on = [ module.kafka, module.druid_raw_cluster ]
+  druid_auth_enabled                = var.druid_auth_enabled
+  druid_admin_username              = var.druid_admin_username
+  druid_admin_password              = var.druid_admin_password
 }
 
 module "velero" {

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -391,6 +391,8 @@ module "druid_raw_cluster" {
   druid_raw_sa_annotations           = "iam.gke.io/gcp-service-account: ${var.building_block}-${var.druid_raw_sa_iam_role_name}@${var.project}.iam.gserviceaccount.com"
   druid_cluster_namespace            = var.druid_raw_namespace
   depends_on                         = [ module.druid_raw_sa_iam_role ]
+  druid_admin_password               = var.druid_admin_password
+  druid_auth_enabled                 = var.druid_auth_enabled
 }
 
 module "kafka_exporter" {

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -320,6 +320,12 @@ variable "druid_auth_enabled" {
   default     = true
 }
 
+variable "druid_admin_username" {
+  type        = string
+  description = "name of druid initial admin user"
+  default     = "admin"
+}
+
 variable "druid_admin_password" {
   type        = string
   description = "Password for druid initial admin user"

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -313,3 +313,15 @@ variable "command_service_image_tag" {
   description = "CommandService image tag."
   default     = "1.0.0"
 }
+
+variable "druid_auth_enabled" {
+  type        = bool
+  description = "Toggle to enable/disable druid basic auth"
+  default     = true
+}
+
+variable "druid_admin_password" {
+  type        = string
+  description = "Password for druid initial admin user"
+  default     = "admin"
+}

--- a/terraform/modules/helm/dataset_api/dataset-api-helm-chart/templates/configmap.yaml
+++ b/terraform/modules/helm/dataset_api/dataset-api-helm-chart/templates/configmap.yaml
@@ -40,7 +40,7 @@ data:
   grafana_url: "{{ .Values.grafana_service.GRAFANA_URL }}"
   grafana_token: "{{ .Values.grafana_service.GRAFANA_TOKEN }}"
   {{- end }}
-  druid_auth_enabled: {{ .Values.druid_auth_enabled }}
+  druid_auth_enabled: "{{ .Values.druid_auth_enabled }}"
   druid_admin_username: "{{ .Values.druid_admin_username }}"
   druid_admin_password: "{{ .Values.druid_admin_password }}"
 

--- a/terraform/modules/helm/dataset_api/dataset-api-helm-chart/templates/configmap.yaml
+++ b/terraform/modules/helm/dataset_api/dataset-api-helm-chart/templates/configmap.yaml
@@ -40,6 +40,8 @@ data:
   grafana_url: "{{ .Values.grafana_service.GRAFANA_URL }}"
   grafana_token: "{{ .Values.grafana_service.GRAFANA_TOKEN }}"
   {{- end }}
-
+  druid_auth_enabled: {{ .Values.druid_auth_enabled }}
+  druid_admin_username: "{{ .Values.druid_admin_username }}"
+  druid_admin_password: "{{ .Values.druid_admin_password }}"
 
 

--- a/terraform/modules/helm/dataset_api/dataset-api-helm-chart/values.yaml
+++ b/terraform/modules/helm/dataset_api/dataset-api-helm-chart/values.yaml
@@ -47,3 +47,7 @@ EXCLUDE_DATASOURCE_VALIDATION: "system-stats,failed-events-summary,masterdata-sy
 
 service_account_annotations:
   eks.amazonaws.com/role-arn: ""
+
+druid_auth_enabled: false
+druid_admin_username: admin
+druid_admin_password: admin

--- a/terraform/modules/helm/dataset_api/dataset-api-helm-chart/values.yaml
+++ b/terraform/modules/helm/dataset_api/dataset-api-helm-chart/values.yaml
@@ -48,6 +48,7 @@ EXCLUDE_DATASOURCE_VALIDATION: "system-stats,failed-events-summary,masterdata-sy
 service_account_annotations:
   eks.amazonaws.com/role-arn: ""
 
+# The basic authentication credentials for the druid will be replaced by the credentials specified in the dataset_api.yaml.tfpl file located in the base directory.
 druid_auth_enabled: false
 druid_admin_username: admin
 druid_admin_password: admin

--- a/terraform/modules/helm/dataset_api/dataset_api.yaml.tfpl
+++ b/terraform/modules/helm/dataset_api/dataset_api.yaml.tfpl
@@ -25,3 +25,6 @@ exhaust_service:
   CONTAINER: ${s3_bucket}
 service_account_annotations:
   ${dataset_api_sa_annotations}
+druid_auth_enabled = ${druid_auth_enabled}
+druid_admin_username = ${druid_admin_username}
+druid_admin_password = ${druid_admin_password}

--- a/terraform/modules/helm/dataset_api/dataset_api.yaml.tfpl
+++ b/terraform/modules/helm/dataset_api/dataset_api.yaml.tfpl
@@ -25,6 +25,6 @@ exhaust_service:
   CONTAINER: ${s3_bucket}
 service_account_annotations:
   ${dataset_api_sa_annotations}
-druid_auth_enabled = ${druid_auth_enabled}
-druid_admin_username = ${druid_admin_username}
-druid_admin_password = ${druid_admin_password}
+druid_auth_enabled : ${druid_auth_enabled}
+druid_admin_username : ${druid_admin_username}
+druid_admin_password : ${druid_admin_password}

--- a/terraform/modules/helm/dataset_api/main.tf
+++ b/terraform/modules/helm/dataset_api/main.tf
@@ -24,6 +24,9 @@ resource "helm_release" "dataset_api" {
           redis_namespace                    = var.redis_namespace
           redis_release_name                 = var.redis_release_name
           s3_bucket                          = var.s3_bucket
+          druid_admin_password               = var.druid_admin_password
+          druid_auth_enabled                 = var.druid_auth_enabled
+          druid_admin_username               = var.druid_admin_username
         }
       )
     ]

--- a/terraform/modules/helm/dataset_api/variables.tf
+++ b/terraform/modules/helm/dataset_api/variables.tf
@@ -110,3 +110,18 @@ variable "s3_bucket" {
   description = "S3 bucket name for dataset api exhaust."
   default     = ""
 }
+
+variable "druid_auth_enabled" {
+  type        = bool
+  description = "Toggle to enable/disable druid basic auth"
+}
+
+variable "druid_admin_username" {
+  type        = string
+  description = "name of druid initial admin user"
+}
+
+variable "druid_admin_password" {
+  type        = string
+  description = "Password for druid initial admin user"
+}

--- a/terraform/modules/helm/druid_raw_cluster/druid-raw-cluster-helm-chart/templates/druid_statefulset.yaml
+++ b/terraform/modules/helm/druid_raw_cluster/druid-raw-cluster-helm-chart/templates/druid_statefulset.yaml
@@ -122,6 +122,23 @@ spec:
     druid.request.logging.dir={{ .Values.druid_request_logging_dir }}
     druid.javascript.enabled=true
     druid.sql.enable={{ .Values.druid_sql_enable }}
+    {{- if .Values.druid_auth_enabled }}
+    druid.auth.authenticatorChain=["MyBasicMetadataAuthenticator"]
+    druid.auth.authenticator.MyBasicMetadataAuthenticator.type=basic
+    druid.auth.authenticator.MyBasicMetadataAuthenticator.initialAdminPassword={{ .Values.druid_admin_password }}
+    druid.auth.authenticator.MyBasicMetadataAuthenticator.initialInternalClientPassword={{ .Values.druid_admin_password }}
+    druid.auth.authenticator.MyBasicMetadataAuthenticator.credentialsValidator.type=metadata
+    druid.auth.authenticator.MyBasicMetadataAuthenticator.skipOnFailure=false
+    druid.auth.authenticator.MyBasicMetadataAuthenticator.authorizerName=MyBasicMetadataAuthorizer
+    # Escalator
+    druid.escalator.type=basic
+    druid.escalator.internalClientUsername=druid_system
+    druid.escalator.internalClientPassword={{ .Values.druid_admin_password }}
+    druid.escalator.authorizerName=MyBasicMetadataAuthorizer
+    # Authorizer
+    druid.auth.authorizers=["MyBasicMetadataAuthorizer"]
+    druid.auth.authorizer.MyBasicMetadataAuthorizer.type=basic
+    {{- end }}
   env:
     - name: POD_NAME
       valueFrom:

--- a/terraform/modules/helm/druid_raw_cluster/druid-raw-cluster-helm-chart/values.yaml
+++ b/terraform/modules/helm/druid_raw_cluster/druid-raw-cluster-helm-chart/values.yaml
@@ -8,7 +8,7 @@ storageClass: "gp2"
 
 ######################### Druid common variables ########################
 druid_directory: "/opt/druid"
-druid_extensions_loadList: '"postgresql-metadata-storage", "druid-kafka-indexing-service", "druid-azure-extensions", "druid-s3-extensions", "druid-google-extensions"'
+druid_extensions_loadList: '"postgresql-metadata-storage", "druid-kafka-indexing-service", "druid-azure-extensions", "druid-s3-extensions", "druid-google-extensions", "druid-basic-security"'
 
 # Logging
 # Log all runtime properties on startup. Disable to avoid logging properties on startup:

--- a/terraform/modules/helm/druid_raw_cluster/druid-raw-cluster-helm-chart/values.yaml
+++ b/terraform/modules/helm/druid_raw_cluster/druid-raw-cluster-helm-chart/values.yaml
@@ -366,5 +366,6 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: druid-raw-sa
 
-druid_auth_enabled: true
+# The basic authentication credentials for the druid will be replaced by the credentials specified in the druid_raw_cluster.yaml.tfpl file located in the base directory.
+druid_auth_enabled: false
 druid_admin_password: admin

--- a/terraform/modules/helm/druid_raw_cluster/druid-raw-cluster-helm-chart/values.yaml
+++ b/terraform/modules/helm/druid_raw_cluster/druid-raw-cluster-helm-chart/values.yaml
@@ -365,3 +365,6 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: druid-raw-sa
+
+druid_auth_enabled: true
+druid_admin_password: admin

--- a/terraform/modules/helm/druid_raw_cluster/druid_raw_cluster.yaml.tfpl
+++ b/terraform/modules/helm/druid_raw_cluster/druid_raw_cluster.yaml.tfpl
@@ -19,3 +19,6 @@ serviceAccount:
   annotations:
     ${druid_raw_sa_annotations}
   name: ${druid_raw_service_account_name}
+
+druid_auth_enabled: ${druid_auth_enabled}
+druid_admin_password: ${druid_admin_password}

--- a/terraform/modules/helm/druid_raw_cluster/main.tf
+++ b/terraform/modules/helm/druid_raw_cluster/main.tf
@@ -29,6 +29,8 @@ resource "helm_release" "druid_cluster" {
         gcs_bucket                     = var.gcs_bucket
         druid_raw_sa_annotations       = var.druid_raw_sa_annotations
         druid_raw_service_account_name = "${var.druid_cluster_namespace}-sa"
+        druid_admin_password           = var.druid_admin_password
+        druid_auth_enabled             = var.druid_auth_enabled
       }
     )
   ]

--- a/terraform/modules/helm/druid_raw_cluster/variables.tf
+++ b/terraform/modules/helm/druid_raw_cluster/variables.tf
@@ -135,3 +135,13 @@ variable "druid_raw_sa_annotations" {
   description = "Service account annotations for druid raw service account."
   default     = "serviceAccountName: default"
 }
+
+variable "druid_auth_enabled" {
+  type        = bool
+  description = "Toggle to enable/disable druid basic auth"
+}
+
+variable "druid_admin_password" {
+  type        = string
+  description = "Password for druid initial admin user"
+}

--- a/terraform/modules/helm/submit_ingestion/main.tf
+++ b/terraform/modules/helm/submit_ingestion/main.tf
@@ -16,6 +16,9 @@ resource "helm_release" "submit_ingestion" {
            submit_ingestion_namespace = var.submit_ingestion_namespace
            druid_cluster_namespace    = var.druid_cluster_namespace
            druid_cluster_release_name = var.druid_cluster_release_name
+           druid_auth_enabled         = var.druid_auth_enabled
+           druid_admin_username       = var.druid_admin_username
+           druid_admin_password       = var.druid_admin_password
         }
       )
     ]

--- a/terraform/modules/helm/submit_ingestion/submit-ingestion-helm-chart/templates/deployment.yaml
+++ b/terraform/modules/helm/submit_ingestion/submit-ingestion-helm-chart/templates/deployment.yaml
@@ -21,6 +21,8 @@ spec:
               
               {{ if .Values.druid_auth_enabled }}
               headers="$headers -H 'Authorization: Basic {{ printf "%s" (printf "%s:%s" .Values.druid_admin_username .Values.druid_admin_password | b64enc) }}'"
+              curl -XPOST $headers -d @/etc/ingestion-spec/system-stats-ingestion-spec.json http://{{ .Values.druid_router_host }}/{{ .Values.supervisor_path }}
+              curl -XPOST $headers -d @/etc/ingestion-spec/masterdata-system-stats-ingestion-spec.json http://{{ .Values.druid_router_host }}/{{ .Values.supervisor_path }}
               {{ end }}
               
               curl -XPOST $headers -d @/etc/ingestion-spec/system-stats-ingestion-spec.json http://{{ .Values.druid_router_host }}/{{ .Values.supervisor_path }}

--- a/terraform/modules/helm/submit_ingestion/submit-ingestion-helm-chart/templates/deployment.yaml
+++ b/terraform/modules/helm/submit_ingestion/submit-ingestion-helm-chart/templates/deployment.yaml
@@ -11,23 +11,21 @@ spec:
         - name: druid
           image: "ubuntu:20.04"
           command:
-            - sh
-            - -c
-            - |
-              apt-get update
-              apt-get install -y curl
-              
-              headers=" -H 'Content-Type: application/json'"
-              
-              {{ if .Values.druid_auth_enabled }}
-              headers="$headers -H 'Authorization: Basic {{ printf "%s" (printf "%s:%s" .Values.druid_admin_username .Values.druid_admin_password | b64enc) }}'"
-              curl -XPOST $headers -d @/etc/ingestion-spec/system-stats-ingestion-spec.json http://{{ .Values.druid_router_host }}/{{ .Values.supervisor_path }}
-              curl -XPOST $headers -d @/etc/ingestion-spec/masterdata-system-stats-ingestion-spec.json http://{{ .Values.druid_router_host }}/{{ .Values.supervisor_path }}
-              {{ end }}
-              
-              curl -XPOST $headers -d @/etc/ingestion-spec/system-stats-ingestion-spec.json http://{{ .Values.druid_router_host }}/{{ .Values.supervisor_path }}
-              curl -XPOST $headers -d @/etc/ingestion-spec/masterdata-system-stats-ingestion-spec.json http://{{ .Values.druid_router_host }}/{{ .Values.supervisor_path }}
-
+          - sh
+          - -c
+          - |
+            apt-get update &&
+            apt-get install -y curl &&
+            BASE_URL="http://{{ .Values.druid_router_host }}/{{ .Values.supervisor_path }}" &&
+            {{ if .Values.druid_auth_enabled }}
+            for spec in /etc/ingestion-spec/*.json; do
+              curl -XPOST  -H 'Authorization: Basic {{ printf "%s" (printf "%s:%s" .Values.druid_admin_username .Values.druid_admin_password | b64enc) }}' -H 'Content-Type: application/json' -d @"$spec" "$BASE_URL"
+            done
+            {{- else}}
+            for spec in /etc/ingestion-spec/*.json; do
+              curl -XPOST -H 'Content-Type: application/json' -d @"$spec" "$BASE_URL"
+            done
+            {{end}}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/ingestion-spec

--- a/terraform/modules/helm/submit_ingestion/submit-ingestion-helm-chart/templates/deployment.yaml
+++ b/terraform/modules/helm/submit_ingestion/submit-ingestion-helm-chart/templates/deployment.yaml
@@ -13,7 +13,19 @@ spec:
           command:
             - sh
             - -c
-            - "apt-get update && apt-get install -y curl && curl -XPOST -H 'Content-Type: application/json' -d @/etc/ingestion-spec/system-stats-ingestion-spec.json http://{{ .Values.druid_router_host }}/{{ .Values.supervisor_path }} && curl -XPOST -H 'Content-Type: application/json' -d @/etc/ingestion-spec/masterdata-system-stats-ingestion-spec.json http://{{ .Values.druid_router_host }}/{{ .Values.supervisor_path }}"
+            - |
+              apt-get update
+              apt-get install -y curl
+              
+              headers=" -H 'Content-Type: application/json'"
+              
+              {{ if .Values.druid_auth_enabled }}
+              headers="$headers -H 'Authorization: Basic {{ printf "%s" (printf "%s:%s" .Values.druid_admin_username .Values.druid_admin_password | b64enc) }}'"
+              {{ end }}
+              
+              curl -XPOST $headers -d @/etc/ingestion-spec/system-stats-ingestion-spec.json http://{{ .Values.druid_router_host }}/{{ .Values.supervisor_path }}
+              curl -XPOST $headers -d @/etc/ingestion-spec/masterdata-system-stats-ingestion-spec.json http://{{ .Values.druid_router_host }}/{{ .Values.supervisor_path }}
+
           volumeMounts:
             - name: config-volume
               mountPath: /etc/ingestion-spec

--- a/terraform/modules/helm/submit_ingestion/submit-ingestion-helm-chart/values.yaml
+++ b/terraform/modules/helm/submit_ingestion/submit-ingestion-helm-chart/values.yaml
@@ -9,6 +9,8 @@ ingestion_spec:
   masterdata_system_stats:
     topic: "sb-dev.masterdata.stats"
     name: "masterdata-system-stats"
+
+# The basic authentication credentials for the druid will be replaced by the credentials specified in the submit_ingestion.yaml.tfpl file located in the base directory.
 druid_auth_enabled: false
 druid_admin_username: admin
 druid_admin_password: admin

--- a/terraform/modules/helm/submit_ingestion/submit-ingestion-helm-chart/values.yaml
+++ b/terraform/modules/helm/submit_ingestion/submit-ingestion-helm-chart/values.yaml
@@ -9,3 +9,6 @@ ingestion_spec:
   masterdata_system_stats:
     topic: "sb-dev.masterdata.stats"
     name: "masterdata-system-stats"
+druid_auth_enabled: false
+druid_admin_username: admin
+druid_admin_password: admin

--- a/terraform/modules/helm/submit_ingestion/submit_ingestion.yaml.tfpl
+++ b/terraform/modules/helm/submit_ingestion/submit_ingestion.yaml.tfpl
@@ -7,6 +7,6 @@ ingestion_spec:
   masterdata_system_stats:
      topic: "${env}.masterdata.stats"
      name: "masterdata-system-stats"
-druid_auth_enabled = ${druid_auth_enabled}
-druid_admin_username = ${druid_admin_username}
-druid_admin_password = ${druid_admin_password}
+druid_auth_enabled : ${druid_auth_enabled}
+druid_admin_username : ${druid_admin_username}
+druid_admin_password : ${druid_admin_password}

--- a/terraform/modules/helm/submit_ingestion/submit_ingestion.yaml.tfpl
+++ b/terraform/modules/helm/submit_ingestion/submit_ingestion.yaml.tfpl
@@ -7,3 +7,6 @@ ingestion_spec:
   masterdata_system_stats:
      topic: "${env}.masterdata.stats"
      name: "masterdata-system-stats"
+druid_auth_enabled = ${druid_auth_enabled}
+druid_admin_username = ${druid_admin_username}
+druid_admin_password = ${druid_admin_password}

--- a/terraform/modules/helm/submit_ingestion/variables.tf
+++ b/terraform/modules/helm/submit_ingestion/variables.tf
@@ -71,3 +71,18 @@ variable "druid_cluster_namespace" {
   type        = any
   description = "druid namespace"
 }
+
+variable "druid_auth_enabled" {
+  type        = bool
+  description = "Toggle to enable/disable druid basic auth"
+}
+
+variable "druid_admin_username" {
+  type        = string
+  description = "name of druid initial admin user"
+}
+
+variable "druid_admin_password" {
+  type        = string
+  description = "Password for druid initial admin user"
+}


### PR DESCRIPTION
**Introduction**

This PR involves automation updates to Druid's basic authentication configuration and modifications on dependent services.

**Expected Outcome**

The changes in this PR should illustrate the effectiveness of enabling and disabling authentication in the cluster.

**Test Scenarios**
- [x] Scenario 1 - Druid raw cluster with authentication both enabled and disabled.
- [x] Scenario 2 - Dataset API with authentication both enabled and disabled.
- [x] Scenario 3 - Submit Ingestion Job with authentication both enabled and disabled.