### PR TITLE
Fix: Remove restart policy from Flink deployment manifest

### DIFF
--- a/terraform/modules/helm/flink/flink-helm-chart/templates/flink_job_deployment.yaml
+++ b/terraform/modules/helm/flink/flink-helm-chart/templates/flink_job_deployment.yaml
@@ -104,7 +104,6 @@ spec:
             path: {{ .Release.Name }}.conf
           - key: log4j_console_properties
             path: log4j-console.properties
-      restartPolicy: OnFailure
       imagePullSecrets:
       - name: {{ .Values.image.imagePullSecrets }}
       serviceAccount: {{ .Release.Namespace }}-sa


### PR DESCRIPTION
**Changes Made:**
- Removed the `restartPolicy` field from the Flink deployment manifest.

**Issue Fixed:**
Description of the bug -  https://github.com/orgs/Sanketika-Obsrv/projects/2/views/42?pane=issue&itemId=45273878