### PR TITLE
feat : #OBS-I321: added required env variable for data observability

### DIFF
--- a/helmcharts/services/dataset-api/values.yaml
+++ b/helmcharts/services/dataset-api/values.yaml
@@ -179,7 +179,9 @@ env:
   prometheus_url: "{{ .Values.global.prometheus.url }}"
   storage_types: '{"lake_house":true,"realtime_store":true}'
   telemetry_dataset: "system.telemetry.events"
-  default_task_duration: "PT4H"
-  default_freshness_threshold: "5" # in minutes
-  data_out_query_time_period: "1d" # one day
-  default_query_time_period: "7" # In Days
+  default_task_duration: "PT4H" # Druid Supervisor task default duration value
+
+  ## Below metrics are used for data observability
+  default_freshness_threshold: "5" # In Minutes, default freshness threshold for data observability
+  data_out_query_time_period: "1d" # In Days, default query time period for data out generally to identify number of api calls are happened with in one or configured value day and used only in the prometheus query
+  default_query_time_period: "7" # In Days, For any metrics the default query time period is 7 days in the druid

--- a/helmcharts/services/dataset-api/values.yaml
+++ b/helmcharts/services/dataset-api/values.yaml
@@ -180,6 +180,6 @@ env:
   storage_types: '{"lake_house":true,"realtime_store":true}'
   telemetry_dataset: "system.telemetry.events"
   default_task_duration: "PT4H"
-  default_freshness_threshold: "5"
-  data_out_query_time_period: "1d"
+  default_freshness_threshold: "5" # in minutes
+  data_out_query_time_period: "1d" # one day
   default_query_time_period: "7" # In Days

--- a/helmcharts/services/dataset-api/values.yaml
+++ b/helmcharts/services/dataset-api/values.yaml
@@ -179,3 +179,7 @@ env:
   prometheus_url: "{{ .Values.global.prometheus.url }}"
   storage_types: '{"lake_house":true,"realtime_store":true}'
   telemetry_dataset: "system.telemetry.events"
+  default_task_duration: "PT4H"
+  default_freshness_threshold: "5"
+  data_out_query_time_period: "1d"
+  default_query_time_period: "7" # In Days


### PR DESCRIPTION
1. default freshness threshold is in minutes
2. data out query time period default to one day
3. default_query_time_period is in days for the query intervals
4. default_task_duration in ingestion spect default to 4 hrs