### PR TITLE
Eks-Upgrade-1.3.2-I333

### DIFF
--- a/terraform/modules/aws/eks/variables.tf
+++ b/terraform/modules/aws/eks/variables.tf
@@ -77,7 +77,7 @@ variable "eks_node_group_scaling_config" {
 variable "eks_version" {
   type        = string
   description = "EKS version."
-  default     = "1.31"
+  default     = "1.32"
 }
 
 variable "eks_addons" {
@@ -89,15 +89,15 @@ variable "eks_addons" {
   default = [
     {
     name  = "kube-proxy"
-    version = "v1.31.0-eksbuild.5"
+    version = "v1.32.0-eksbuild.2"
     },
     {
     name  = "vpc-cni"
-    version = "v1.18.3-eksbuild.3"
+    version = "v1.19.2-eksbuild.1"
     },
     {
     name  = "coredns"
-    version = "v1.11.3-eksbuild.1"
+    version = "v1.11.4-eksbuild.2"
     },
     {
     name  = "aws-ebs-csi-driver"


### PR DESCRIPTION
Upgraded eks version from 1.3.1 to 1.3.2, updated addons like kube-proxy, vpc-cni, core dns and csi driver.