### PR TITLE
Enabled authentication for druid web console

### DIFF
--- a/helmcharts/bootstrapper/templates/secrets.yaml
+++ b/helmcharts/bootstrapper/templates/secrets.yaml
@@ -33,6 +33,15 @@ subjects:
   - kind: ServiceAccount
     name: obsrv-bootstrap-secrets-job-sa
 ---
+apiVersion: v1
+data:
+  .dockerconfigjson: {{ .Values.global.image.dockerConfigJson | b64enc }}
+kind: Secret
+metadata:
+  name: {{ .Values.global.image.dockerRegistrySecretName }}
+  namespace: {{ .Release.Namespace }}
+type: kubernetes.io/dockerconfigjson
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -44,8 +53,12 @@ spec:
   template:
     spec:
       serviceAccountName: obsrv-bootstrap-secrets-job-sa
+      imagePullSecrets:
+      - name: {{ $.Values.global.image.dockerRegistrySecretName }}
+
       containers:
       - name: openssl
+        imagePullPolicy: IfNotPresent
         image: sanketikahub/kubectl:1.32.0-r1
         command:
         - /bin/sh

--- a/helmcharts/global-cloud-values-aws.yaml
+++ b/helmcharts/global-cloud-values-aws.yaml
@@ -189,6 +189,7 @@ druid-raw-cluster:
   s3_access_key: ""
   s3_secret_key: ""
   <<: *druid-raw-service-account
+  druid_auth_enabled: false
 
 lakehouse-connector:
   hadoop_core_site:

--- a/helmcharts/global-cloud-values-azure.yaml
+++ b/helmcharts/global-cloud-values-azure.yaml
@@ -197,6 +197,7 @@ druid-raw-cluster:
   azure_storage_account_key: *azure_storage_account_key
   azure_storage_container: *cloud_storage_bucket
   <<: *druid-raw-service-account
+  druid_auth_enabled: false
 
 secor-service-account: &secor-service-account
   serviceAccount:

--- a/helmcharts/global-cloud-values-gcp.yaml
+++ b/helmcharts/global-cloud-values-gcp.yaml
@@ -102,6 +102,7 @@ druid-raw-cluster:
   druid_deepstorage_type: *deep_store_type
   druid_indexer_logs_type: *deep_store_type
   gcs_bucket: *cloud_storage_bucket
+  druid_auth_enabled: false
 
 flink:
   !!merge <<: *flink-service-account

--- a/helmcharts/global-values.yaml
+++ b/helmcharts/global-values.yaml
@@ -80,6 +80,11 @@ defaults:
     admin_user: &superset_admin_user "admin"
     admin_password: &superset_admin_password "admin123"
 
+  druid_users:
+    admin_password: &druid_admin_password "admin123"
+    escalator_username: &druid_escalator_username "druid_system"
+    escalator_password: &druid_escalator_password "internal123"
+
   # config_service_host: &config-service-host "http://command-api.command-api.svc.cluster.local"
   # druid_host: &global-druid-host "http://druid-raw-routers.druid-raw.svc.cluster.local"
   druid_url: &global-druid-url "http://druid-raw-routers.druid-raw.svc.cluster.local:8888"
@@ -315,6 +320,10 @@ druid-raw-cluster: &druid-raw-cluster
   druid_metadata_storage_connector_password: *psql-druid-pwd
   zookeeper:
     namespace: *druid-namespace
+  druid_auth_admin_password: *druid_admin_password
+  druid_auth_escalator_username: *druid_escalator_username
+  druid_auth_escalator_password: *druid_escalator_password
+
 
 druid-operator:
   namespace: *druid-namespace

--- a/helmcharts/images.yaml
+++ b/helmcharts/images.yaml
@@ -421,6 +421,8 @@ internal: &internal
   postgresql:
     image:
       <<: *postgresql
+      pullSecrets:
+      - *dockerSecretName
 
   hms:
     image:
@@ -534,6 +536,8 @@ internal: &internal
   druid-operator:
     image:
       <<: *druid_operator
+      pullSecrets:
+      - *dockerSecretName
 
   kafka-message-exporter:
     imagePullSecrets: *imagePullSecrets

--- a/helmcharts/local-datacenter.yaml
+++ b/helmcharts/local-datacenter.yaml
@@ -85,6 +85,7 @@ druid-raw-cluster:
   druid_s3_endpoint_signingRegion: *s3-signing-region
   druid_s3_protocol: *s3-protocol
   druid_s3_path_style_access: *s3-path-style-access
+  druid_auth_enabled: false
 
 kafka:
   persistence:

--- a/helmcharts/services/druid-raw-cluster/templates/druid_statefulset.yaml
+++ b/helmcharts/services/druid-raw-cluster/templates/druid_statefulset.yaml
@@ -59,16 +59,18 @@ spec:
     druid.startup.logging.logProperties=true
 
     #Druid console - basic security authentication 
-    druid.auth.enabled=true
+    druid.auth.enabled={{ .Values.druid_auth_enabled }}
     druid.auth.authenticatorChain=["MyBasicMetadataAuthenticator"]
     druid.auth.authenticator.MyBasicMetadataAuthenticator.type=basic
-    druid.auth.authenticator.MyBasicMetadataAuthenticator.initialAdminPassword=<password> #Replace with actual password
+    #the property initialAdminPassword only creates a user named admin by default and does not allow changing the username via config
+    druid.auth.authenticator.MyBasicMetadataAuthenticator.initialAdminPassword={{ .Values.druid_auth_admin_password }}
+    druid.auth.authenticator.MyBasicMetadataAuthenticator.initialInternalClientPassword={{ .Values.druid_auth_escalator_password }}
     druid.auth.authenticator.MyBasicMetadataAuthenticator.credentialsValidator.type=metadata
     druid.auth.authenticator.MyBasicMetadataAuthenticator.skipOnFailure=false
     druid.auth.authenticator.MyBasicMetadataAuthenticator.authorizerName=MyBasicMetadataAuthorizer
     druid.escalator.type=basic
-    druid.escalator.internalClientUsername=druid_system
-    druid.escalator.internalClientPassword=<password> #Replace with actual password
+    druid.escalator.internalClientUsername={{ .Values.druid_auth_escalator_username }}
+    druid.escalator.internalClientPassword={{ .Values.druid_auth_escalator_password }}
     druid.escalator.authorizerName=MyBasicMetadataAuthorizer
     druid.auth.authorizers=["MyBasicMetadataAuthorizer"]
     druid.auth.authorizer.MyBasicMetadataAuthorizer.type=basic

--- a/helmcharts/services/druid-raw-cluster/templates/druid_statefulset.yaml
+++ b/helmcharts/services/druid-raw-cluster/templates/druid_statefulset.yaml
@@ -57,6 +57,22 @@ spec:
     # Logging
     # Log all runtime properties on startup. Disable to avoid logging properties on startup:
     druid.startup.logging.logProperties=true
+
+    #Druid console - basic security authentication 
+    druid.auth.enabled=true
+    druid.auth.authenticatorChain=["MyBasicMetadataAuthenticator"]
+    druid.auth.authenticator.MyBasicMetadataAuthenticator.type=basic
+    druid.auth.authenticator.MyBasicMetadataAuthenticator.initialAdminPassword=<password> #Replace with actual password
+    druid.auth.authenticator.MyBasicMetadataAuthenticator.credentialsValidator.type=metadata
+    druid.auth.authenticator.MyBasicMetadataAuthenticator.skipOnFailure=false
+    druid.auth.authenticator.MyBasicMetadataAuthenticator.authorizerName=MyBasicMetadataAuthorizer
+    druid.escalator.type=basic
+    druid.escalator.internalClientUsername=druid_system
+    druid.escalator.internalClientPassword=<password> #Replace with actual password
+    druid.escalator.authorizerName=MyBasicMetadataAuthorizer
+    druid.auth.authorizers=["MyBasicMetadataAuthorizer"]
+    druid.auth.authorizer.MyBasicMetadataAuthorizer.type=basic
+
     # Zookeeper
     druid.zk.service.host={{ .Release.Name }}-zookeeper-headless.{{ .Values.namespace }}.svc.cluster.local
     druid.zk.paths.base=/druid

--- a/helmcharts/services/druid-raw-cluster/values.yaml
+++ b/helmcharts/services/druid-raw-cluster/values.yaml
@@ -381,3 +381,11 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: druid-raw-sa
+
+#################### Druid Auth Variables ######################
+
+  druid_auth_enabled: false
+  druid_auth_admin_password: admin123
+  druid_auth_escalator_username: druid_system
+  druid_auth_escalator_password: internal123
+  

--- a/helmcharts/services/druid-raw-cluster/values.yaml
+++ b/helmcharts/services/druid-raw-cluster/values.yaml
@@ -17,7 +17,7 @@ storageClass: ""
 
 ######################### Druid common variables ########################
 druid_directory: "/opt/druid"
-druid_extensions_loadList: '"postgresql-metadata-storage", "druid-kafka-indexing-service", "druid-azure-extensions", "druid-s3-extensions", "druid-google-extensions", "prometheus-emitter", "druid-datasketches"'
+druid_extensions_loadList: '"druid-basic-security","postgresql-metadata-storage", "druid-kafka-indexing-service", "druid-azure-extensions", "druid-s3-extensions", "druid-google-extensions", "prometheus-emitter", "druid-datasketches"'
 
 # Logging
 # Log all runtime properties on startup. Disable to avoid logging properties on startup:


### PR DESCRIPTION
- Add `druid-basic-security` extension to `druid.extensions.loadList` to enable basic authentication.
- Set up the basic Authenticator, Authorizer, and Escalator config in `common.runtime.properties` :

   ```
    druid.auth.enabled=true
    druid.auth.authenticatorChain=["MyBasicMetadataAuthenticator"]
    druid.auth.authenticator.MyBasicMetadataAuthenticator.type=basic
    druid.auth.authenticator.MyBasicMetadataAuthenticator.initialAdminPassword=<password> #Replace with actual password
    druid.auth.authenticator.MyBasicMetadataAuthenticator.credentialsValidator.type=metadata
    druid.auth.authenticator.MyBasicMetadataAuthenticator.skipOnFailure=false
    druid.auth.authenticator.MyBasicMetadataAuthenticator.authorizerName=MyBasicMetadataAuthorizer
    druid.escalator.type=basic
    druid.escalator.internalClientUsername=druid_system
    druid.escalator.internalClientPassword=<password> #Replace with actual password
    druid.escalator.authorizerName=MyBasicMetadataAuthorizer
    druid.auth.authorizers=["MyBasicMetadataAuthorizer"]
    druid.auth.authorizer.MyBasicMetadataAuthorizer.type=basic

- Verified by logging into the console using the configured credentials.