### PR TITLE
Druid Upgrade to 32.0.1

### DIFF
--- a/Dockerfiles/druid/Dockerfile
+++ b/Dockerfiles/druid/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/druid:28.0.1
+FROM apache/druid:32.0.1
 
 RUN chmod -R 755 /opt/druid/bin
 USER druid

--- a/helmcharts/images.yaml
+++ b/helmcharts/images.yaml
@@ -325,7 +325,7 @@ images: &images
   druid-raw-cluster: &druid-raw-cluster
     registry: *global_registry
     repository: druid
-    tag: "28.0.1"
+    tag: "32.0.1"
     digest: ""
 
   druid_exporter: &druid_exporter

--- a/helmcharts/services/druid-raw-cluster/values.yaml
+++ b/helmcharts/services/druid-raw-cluster/values.yaml
@@ -8,7 +8,7 @@ global:
 
 registry: "apache"
 repository: "druid"
-tag: "28.0.1"
+tag: "32.0.1"
 digest: ""
 
 druid_monitoring: True

--- a/terraform/modules/helm/druid_raw_cluster/druid-raw-cluster-helm-chart/values.yaml
+++ b/terraform/modules/helm/druid_raw_cluster/druid-raw-cluster-helm-chart/values.yaml
@@ -1,6 +1,6 @@
 druid_env: "dev"
 druid_cluster_type: "raw"
-druid_image: "apache/druid:28.0.1"
+druid_image: "apache/druid:32.0.1"
 druid_namespace: "druid-raw"
 druid_monitoring: True
 mount_path: /druid/data


### PR DESCRIPTION
- Upgraded druid from 28.0.1 to 32.0.1.
- Verified by :
   1. The data sources present before the upgrade are still available after upgrading.
   2. Verified by creating a new data source after upgrading to version 32.0.1.
   3. Successfully queried data from the newly created data source.