### PR TITLE
Register Available connectors by default

### DIFF
--- a/connectors/register.sh
+++ b/connectors/register.sh
@@ -2,6 +2,18 @@
 
 dataset_api_port=3000
 dataset_api_host="localhost"
+BEARER_TOKEN="<your_bearer_token>"
+
+# Steps to generate the Bearer token:
+# 1. ssh into the keycloak pod:
+# 2. Run the following command to get the token:
+#    curl --insecure -X POST 'http://10.244.0.20:8080/auth/realms/obsrv/protocol/openid-connect/token' \
+#   -H 'Content-Type: application/x-www-form-urlencoded' \
+#   --data-urlencode 'client_id=obsrv-console' \
+#   --data-urlencode 'username=<your_username>' \ #management-console username
+#   --data-urlencode 'password=<your_password>' \ #management-console password
+#   --data-urlencode 'grant_type=password'
+
 
 # function to check and install kubectl
 install_kubectl() {
@@ -121,7 +133,7 @@ register_connectors() {
 
     echo "Registering: $asset_name to Dataset API..."
     curl --progress-bar --location "http://$dataset_api_host:$dataset_api_port/v2/connector/register" \
-      --header 'Content-Type: multipart/form-data' \
+      --header "Authorization: Bearer $BEARER_TOKEN" \
       --form "file=@$output_path"
 
     echo "Cleaning up: $output_path"


### PR DESCRIPTION
During the deployment of Enterprise Automation, connector registration requires a Bearer token due to RBAC being enabled. To successfully register a connector, the token must be included in the request headers.