### PR TITLE
Disable autoscaling of node pools.

### DIFF
--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -141,6 +141,7 @@ module "gke_cluster" {
   gke_node_pool_scaling_config    = var.gke_node_pool_scaling_config
 
   enable_vertical_pod_autoscaling = var.enable_vertical_pod_autoscaling
+  enable_autoscaling              = var.enable_autoscaling
 
   alternative_default_service_account = var.override_default_node_pool_service_account ? module.gke_service_account.email : null
 

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -312,3 +312,9 @@ variable "kubectl_config_context" {
   type        = string
   default     = "gke_"
 }
+
+variable "enable_autoscaling" {
+  description = "Enable autoscaling for the GKE node pool"
+  type        = bool
+  default     = false
+}

--- a/terraform/gcp/vars/cluster_overrides.tfvars
+++ b/terraform/gcp/vars/cluster_overrides.tfvars
@@ -24,3 +24,4 @@ services_secondary_range_name = ""
 
 # cluster node pool configuration
 gke_node_default_disk_size_gb = 30
+enable_autoscaling            = false

--- a/terraform/modules/gcp/gke-cluster/main.tf
+++ b/terraform/modules/gcp/gke-cluster/main.tf
@@ -217,6 +217,7 @@ resource "google_container_node_pool" "node_pool" {
   initial_node_count = var.gke_node_pool_scaling_config["desired_size"]
 
   autoscaling {
+    enabled        = var.enable_autoscaling
     min_node_count = var.gke_node_pool_scaling_config["min_size"]
     max_node_count = var.gke_node_pool_scaling_config["max_size"]
   }

--- a/terraform/modules/gcp/gke-cluster/variables.tf
+++ b/terraform/modules/gcp/gke-cluster/variables.tf
@@ -300,3 +300,9 @@ variable "gke_node_default_disk_size_gb" {
   type        = number
   default     = 30
 }
+
+variable "enable_autoscaling" {
+  description = "Enable autoscaling for the node pool"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a configurable option to enable or disable autoscaling for GKE node pools.
  - Supports toggling at both module and environment levels; default remains disabled to preserve current behavior.

- Chores
  - Updated environment overrides to include the new autoscaling setting.
  - No impact to existing clusters unless the option is explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->