### PR TITLE
Mount config file for master data processor spark job

### DIFF
--- a/helmcharts/services/spark/templates/configmap.yaml
+++ b/helmcharts/services/spark/templates/configmap.yaml
@@ -25,3 +25,16 @@ metadata:
 data:
   {{- $var := .Files.Get "configs/env.yaml" }}
   {{- include "common.tplvalues.render" (dict "value" $var "context" $) | nindent 2 }}
+  
+---
+{{- $flinkConfig := lookup "v1" "ConfigMap" "flink" "unified-pipeline-config" }}
+{{- if $flinkConfig }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: flink-baseconfig
+  namespace: {{ include "base.namespace" . | quote }}
+data:
+  baseconfig.conf: |
+{{ $flinkConfig.data.baseconfig | nindent 4 }}
+{{- end }}

--- a/helmcharts/services/spark/values.yaml
+++ b/helmcharts/services/spark/values.yaml
@@ -291,7 +291,10 @@ master:
           python3 /data/connectors-init/connector.py
   ## @param master.extraVolumes Optionally specify extra list of additional volumes for the master pod(s)
   ##
-  extraVolumes: []
+  extraVolumes:
+    - name: flink-config
+      configMap:
+        name: flink-baseconfig
   ## @param master.extraVolumeMounts Optionally specify extra list of additional volumeMounts for the master container(s)
   ##
   extraVolumeMounts:
@@ -301,6 +304,9 @@ master:
       mountPath: /opt/bitnami/spark/spark-metadata
     - name: "{{ .Values.persistence.connectorData.name }}"
       mountPath: /data/connectors
+    - name: flink-config
+      mountPath: /data/flink/conf
+      readOnly: true
   ## Container resource requests and limits
   ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
   ## We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Optionally generates a flink-baseconfig ConfigMap when a unified-pipeline-config exists, exposing baseconfig.conf for Spark.
  - Spark Master can now mount this configuration via new values:
    - master.extraVolumes: adds a ConfigMap-based volume (flink-config).
    - master.extraVolumeMounts: mounts flink-config read-only at /data/flink/conf.
  - Enhances cross-service configuration sharing without affecting existing Spark config behavior.
- Chores
  - Helm chart updated to conditionally render the additional ConfigMap alongside existing templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->