### PR TITLE
#feat: superset version upgrade to 6.x with workflow for image creation

### DIFF
--- a/.github/workflows/superset-build.yaml
+++ b/.github/workflows/superset-build.yaml
@@ -1,0 +1,31 @@
+name: Build and Push Superset Image
+run-name: Build superset image ${{ inputs.superset_version }}
+on:
+  workflow_dispatch:
+    inputs:
+      superset_version:
+        description: "Superset image tag to publish (e.g. 6.1.0)"
+        required: true
+        type: string
+
+jobs:
+  build-superset-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Login to docker hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build docker image and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./Dockerfiles/superset
+          file: ./Dockerfiles/superset/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ vars.DOCKERHUB_USERNAME }}/superset:${{ inputs.superset_version }}

--- a/.github/workflows/superset-build.yaml
+++ b/.github/workflows/superset-build.yaml
@@ -1,5 +1,7 @@
 name: Build and Push Superset Image
 run-name: Build superset image ${{ inputs.superset_version }}
+permissions:
+  contents: read
 on:
   workflow_dispatch:
     inputs:

--- a/Dockerfiles/superset/Dockerfile
+++ b/Dockerfiles/superset/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/superset:4.1.1
+FROM apache/superset:6.1.0
 USER root
-RUN pip install Authlib psycopg2-binary pydruid sqlalchemy-trino
+RUN uv pip install --python /app/.venv/bin/python Authlib psycopg2-binary pydruid sqlalchemy-trino
 USER superset

--- a/helmcharts/images.yaml
+++ b/helmcharts/images.yaml
@@ -237,7 +237,7 @@ images: &images
   superset: &superset
     registry: *global_registry
     repository: "superset"
-    tag: "4.1.1"
+    tag: "6.1.0"
     digest: ""
 
   secor: &secor

--- a/helmcharts/services/superset/values.yaml
+++ b/helmcharts/services/superset/values.yaml
@@ -449,7 +449,7 @@ extraSecrets:
     class CustomSsoSecurityManager(SupersetSecurityManager):
       def __init__(self, appbuilder):
         super(CustomSsoSecurityManager, self).__init__(appbuilder)
-        app = self.appbuilder.get_app
+        app = self.appbuilder.app
         app.config.setdefault("AUTH_ROLES_MAPPING", {})
         app.config.setdefault("AUTH_TYPE", AUTH_OAUTH)
 
@@ -542,6 +542,7 @@ configOverrides:
     AUTH_OAUTH_REDIRECT_URI='http{{ if .Values.global.ssl_enabled }}s{{ end }}://{{ .Values.global.domain }}/oauth-authorized/obsrv'
     AUTH_USER_REGISTRATION_ROLE = "Admin"
     ENABLE_PROXY_FIX = {{ if .Values.global.ssl_enabled }}True{{ else }}False{{ end }}
+    TALISMAN_ENABLED = {{ if .Values.global.ssl_enabled }}True{{ else }}False{{ end }}
 
     from custom_sso_security_manager import CustomSsoSecurityManager
     CUSTOM_SECURITY_MANAGER = CustomSsoSecurityManager


### PR DESCRIPTION
# Superset Upgrade: 4.1.1 → 6.1.0

## Overview

Upgrade of the custom Superset image (`sanketikahub/superset`) from `4.1.1` to `6.1.0`. Adds a GitHub Actions workflow to build and publish the image. Required four code changes plus one new workflow file.

---

## Changes

### 1. `Dockerfiles/superset/Dockerfile`

```diff
-FROM apache/superset:4.1.1
+FROM apache/superset:6.1.0
 USER root
-RUN pip install Authlib psycopg2-binary pydruid sqlalchemy-trino
+RUN uv pip install --python /app/.venv/bin/python Authlib psycopg2-binary pydruid sqlalchemy-trino
 USER superset
```

**Why:**

- **Base image bump** to `apache/superset:6.1.0` — picks up all upstream fixes, schema, frontend.
- **`pip` → `uv pip install --python /app/.venv/bin/python`** — Superset 5.x switched the official image to a uv-managed virtualenv at `/app/.venv` (UPDATING.md PR #31260). Plain `pip install` installs into the system Python, where Superset cannot find the packages — pods crash with `ModuleNotFoundError: No module named 'psycopg2'`. The `uv pip` invocation installs the drivers (Authlib, psycopg2-binary, pydruid, sqlalchemy-trino) into the virtualenv Superset actually uses.

### 2. `helmcharts/services/superset/values.yaml` — line 452 (CustomSsoSecurityManager)

```diff
     class CustomSsoSecurityManager(SupersetSecurityManager):
       def __init__(self, appbuilder):
         super(CustomSsoSecurityManager, self).__init__(appbuilder)
-        app = self.appbuilder.get_app
+        app = self.appbuilder.app
```

**Why:**

Superset 6.0 upgrades Flask-AppBuilder (FAB) to 5.0 (UPDATING.md PR #33055). The `appbuilder.get_app` attribute was removed in FAB 5; the replacement is `appbuilder.app`. Without this change, Superset 6.x pods crash on startup with:

```
AttributeError: 'AppBuilder' object has no attribute 'get_app'
```

The custom security manager is loaded during `configure_fab()`, so the app fails before Gunicorn can serve anything.

### 3. `helmcharts/services/superset/values.yaml` — line 545 (TALISMAN gating)

```diff
     ENABLE_PROXY_FIX = {{ if .Values.global.ssl_enabled }}True{{ else }}False{{ end }}
+    TALISMAN_ENABLED = {{ if .Values.global.ssl_enabled }}True{{ else }}False{{ end }}
```

**Why:**

Superset 6.x enables Flask-Talisman by default, which sends HSTS and `Content-Security-Policy: upgrade-insecure-requests` response headers. On HTTP-only deployments (typical dev / LAN clusters), Chrome caches these directives and forces all future requests to HTTPS. Since the host nginx only listens on port 80, the upgraded request fails with `ERR_ADDRESS_UNREACHABLE`. The cached directive persists across browser sessions and survives downgrades — once Chrome learns the rule, it sticks.

Gating Talisman on `ssl_enabled` mirrors the existing `ENABLE_PROXY_FIX` pattern:

- `ssl_enabled: false` → `TALISMAN_ENABLED = False` (no HTTPS-upgrade directive sent, browsers stay happy on HTTP)
- `ssl_enabled: true` → `TALISMAN_ENABLED = True` (full security headers; HSTS is valid because real HTTPS exists)

### 4. `.github/workflows/superset-build.yaml` (new)

A `workflow_dispatch`-only workflow that builds the Superset image and pushes it to DockerHub.

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflow for building and deploying Superset Docker images
  * Upgraded Superset service to version 6.1.0 across deployment configurations
  * Enhanced security with additional protection layer when SSL is enabled
  * Optimized single sign-on system integration and configuration handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Sanketika-Obsrv/obsrv-automation/pull/363?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->