### PR TITLE
#feat: service account support for trino and hms

### DIFF
--- a/Dockerfiles/hms/Dockerfile
+++ b/Dockerfiles/hms/Dockerfile
@@ -1,9 +1,9 @@
-FROM --platform=linux/amd64 openjdk:16-slim
+FROM --platform=linux/amd64 eclipse-temurin:17-jre-jammy
 
 # Lifted from: https://github.com/joshuarobinson/presto-on-k8s/blob/1c91f0b97c3b7b58bdcdec5ad6697b42e50d74c7/hive_metastore/Dockerfile
 
 # see https://hadoop.apache.org/releases.html
-ARG HADOOP_VERSION=3.3.0
+ARG HADOOP_VERSION=3.3.4
 # see https://downloads.apache.org/hive/
 ARG HIVE_METASTORE_VERSION=3.0.0
 # see https://jdbc.postgresql.org/download.html#current

--- a/helmcharts/global-cloud-values-aws.yaml
+++ b/helmcharts/global-cloud-values-aws.yaml
@@ -199,9 +199,8 @@ druid-raw-cluster:
 
 lakehouse-connector:
   hadoop_core_site:
-      fs.s3a.imp: org.apache.hadoop.fs.s3a.S3AFileSystem
-      fs.s3a.access.key: *s3-access-key
-      fs.s3a.secret.key: *s3-secret-access-key
+    fs.s3a.impl: org.apache.hadoop.fs.s3a.S3AFileSystem
+    fs.s3a.aws.credentials.provider: com.amazonaws.auth.WebIdentityTokenCredentialsProvider
   serviceAccount:
     create: false
     name: flink-sa
@@ -223,8 +222,6 @@ trino:
       hive.metastore.uri=thrift://hudi-hms.hms.svc.cluster.local:9083
       fs.native-s3.enabled=true
       s3.region=<fill-value>
-      s3.aws-access-key=
-      s3.aws-secret-key=
 
 hms:
   serviceAccount:
@@ -238,8 +235,7 @@ hms:
 
   hadoop_core_site:
     fs.s3a.impl: org.apache.hadoop.fs.s3a.S3AFileSystem
-    fs.s3a.access.key: ""
-    fs.s3a.secret.key: ""
+    fs.s3a.aws.credentials.provider: com.amazonaws.auth.WebIdentityTokenCredentialsProvider
     # fs.s3a.endpoint: *s3-endpoint-url
     # fs.s3a.path.style.access: false
     # fs.s3a.connection.ssl.enabled: true

--- a/helmcharts/global-cloud-values-aws.yaml
+++ b/helmcharts/global-cloud-values-aws.yaml
@@ -49,6 +49,10 @@ service_accounts:
     eks.amazonaws.com/role-arn: "<fill-value>" # Update with the ARN of the IAM role for this service account
   velero: &velero_sa_annotation
     eks.amazonaws.com/role-arn: "<fill-value>" # Update with the ARN of the IAM role for this service account
+  trino: &trino_sa_annotation
+    eks.amazonaws.com/role-arn: "<fill-value>" # Update with the ARN of the trino_sa_iam_role (terraform module.eks output trino_sa_iam_role)
+  hms: &hms_sa_annotation
+    eks.amazonaws.com/role-arn: "<fill-value>" # Update with the ARN of the hms_sa_iam_role (terraform module.eks output hms_sa_iam_role)
 
 s3-exporter-service-account: &s3-exporter-service-account
   s3_region: *cloud_storage_region
@@ -208,22 +212,34 @@ lakehouse-connector:
       <<: *flink_sa_annotation
 
 trino:
+  serviceAccount:
+    create: *create_sa
+    name: trino-sa
+    annotations:
+      <<: *trino_sa_annotation
   additionalCatalogs:
     lakehouse: |-
       connector.name=hudi
       hive.metastore.uri=thrift://hudi-hms.hms.svc.cluster.local:9083
       fs.native-s3.enabled=true
-      s3.aws-access-key=<fill-value>
-      s3.aws-secret-key=<fill-value>
+      s3.region=<fill-value>
+      s3.aws-access-key=
+      s3.aws-secret-key=
 
 hms:
+  serviceAccount:
+    create: *create_sa
+    automount: true
+    name: hms-sa
+    annotations:
+      <<: *hms_sa_annotation
   envVars:
     WAREHOUSE_DIR: *hudi_metadata_bucket
 
-
   hadoop_core_site:
-    fs.s3a.access.key:  *s3-access-key
-    fs.s3a.secret.key:  *s3-secret-access-key
+    fs.s3a.impl: org.apache.hadoop.fs.s3a.S3AFileSystem
+    fs.s3a.access.key: ""
+    fs.s3a.secret.key: ""
     # fs.s3a.endpoint: *s3-endpoint-url
     # fs.s3a.path.style.access: false
     # fs.s3a.connection.ssl.enabled: true

--- a/helmcharts/services/hms/templates/serviceaccount.yaml
+++ b/helmcharts/services/hms/templates/serviceaccount.yaml
@@ -10,5 +10,4 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
 {{- end }}

--- a/helmcharts/services/hms/templates/serviceaccount.yaml
+++ b/helmcharts/services/hms/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "metastore-app.serviceAccountName" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "metastore-app.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helmcharts/services/hms/values.yaml
+++ b/helmcharts/services/hms/values.yaml
@@ -9,7 +9,7 @@ image:
   registry: sanketikahub
   repository: hms
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.0.4"
+  tag: "1.0.5"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/helmcharts/services/lakehouse-connector/templates/deployment.yaml
+++ b/helmcharts/services/lakehouse-connector/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
       {{- range .Values.image.imagePullSecrets }}
         - name: {{ . }}
       {{- end }}
-      {{- if .Values.serviceAccount.create }}
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
       serviceAccountName: {{ include "base.serviceaccountname" . }}
       {{- end }}
       volumes:
@@ -190,7 +190,9 @@ spec:
       {{- range .Values.image.imagePullSecrets }}
         - name: {{ . }}
       {{- end }}
-      # serviceAccount: flink-sa
+      {{- if or .Values.serviceAccount.create .Values.serviceAccount.name }}
+      serviceAccountName: {{ include "base.serviceaccountname" . }}
+      {{- end }}
       volumes:
       - configMap:
           items:

--- a/terraform/aws/global-cloud-values-aws.yaml.tfpl
+++ b/terraform/aws/global-cloud-values-aws.yaml.tfpl
@@ -195,9 +195,8 @@ druid-raw-cluster:
 
 lakehouse-connector:
   hadoop_core_site:
-      fs.s3a.imp: org.apache.hadoop.fs.s3a.S3AFileSystem
-      fs.s3a.access.key: *s3-access-key
-      fs.s3a.secret.key: *s3-secret-access-key
+      fs.s3a.impl: org.apache.hadoop.fs.s3a.S3AFileSystem
+      fs.s3a.aws.credentials.provider: com.amazonaws.auth.WebIdentityTokenCredentialsProvider
   serviceAccount:
     create: false
     name: flink-sa
@@ -234,8 +233,7 @@ hms:
 
   hadoop_core_site:
     fs.s3a.impl: org.apache.hadoop.fs.s3a.S3AFileSystem
-    fs.s3a.access.key: ""
-    fs.s3a.secret.key: ""
+    fs.s3a.aws.credentials.provider: com.amazonaws.auth.WebIdentityTokenCredentialsProvider
     # fs.s3a.endpoint: *s3-endpoint-url
     # fs.s3a.path.style.access: false
     # fs.s3a.connection.ssl.enabled: true

--- a/terraform/aws/global-cloud-values-aws.yaml.tfpl
+++ b/terraform/aws/global-cloud-values-aws.yaml.tfpl
@@ -48,6 +48,10 @@ service_accounts:
     eks.amazonaws.com/role-arn: "${spark_sa_annotation}"
   velero: &velero_sa_annotation
     eks.amazonaws.com/role-arn: "${velero_sa_annotation}"
+  trino: &trino_sa_annotation
+    eks.amazonaws.com/role-arn: "${trino_sa_annotation}"
+  hms: &hms_sa_annotation
+    eks.amazonaws.com/role-arn: "${hms_sa_annotation}"
 
 s3-exporter-service-account: &s3-exporter-service-account
   s3_region: *cloud_storage_region
@@ -204,22 +208,34 @@ lakehouse-connector:
       <<: *flink_sa_annotation
 
 trino:
+  serviceAccount:
+    create: *create_sa
+    name: trino-sa
+    annotations:
+      <<: *trino_sa_annotation
   additionalCatalogs:
     lakehouse: |-
       connector.name=hudi
       hive.metastore.uri=thrift://hudi-hms.hms.svc.cluster.local:9083
-      hive.s3.aws-access-key=<fill-value>
-      hive.s3.aws-secret-key=<fill-value>
-      hive.s3.ssl.enabled=false
+      fs.native-s3.enabled=true
+      s3.region=${cloud_storage_region}
+      s3.aws-access-key=
+      s3.aws-secret-key=
 
 hms:
+  serviceAccount:
+    create: *create_sa
+    automount: true
+    name: hms-sa
+    annotations:
+      <<: *hms_sa_annotation
   envVars:
     WAREHOUSE_DIR: *hudi_metadata_bucket
 
-
   hadoop_core_site:
-    fs.s3a.access.key:  *s3-access-key
-    fs.s3a.secret.key:  *s3-secret-access-key
+    fs.s3a.impl: org.apache.hadoop.fs.s3a.S3AFileSystem
+    fs.s3a.access.key: ""
+    fs.s3a.secret.key: ""
     # fs.s3a.endpoint: *s3-endpoint-url
     # fs.s3a.path.style.access: false
     # fs.s3a.connection.ssl.enabled: true

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -351,6 +351,8 @@ module "aws_cloud_values" {
     s3_exporter_sa_annotation       = module.eks.s3_exporter_sa_annotations != null ? module.eks.s3_exporter_sa_annotations : ""
     spark_sa_annotation             = module.eks.spark_sa_annotations != null ? module.eks.spark_sa_annotations : ""
     velero_sa_annotation            = module.eks.velero_backup_sa_annotation != null ? module.eks.velero_backup_sa_annotation : ""
+    trino_sa_annotation             = module.eks.trino_sa_iam_role != null ? module.eks.trino_sa_iam_role : ""
+    hms_sa_annotation               = module.eks.hms_sa_iam_role != null ? module.eks.hms_sa_iam_role : ""
 
     load_balancer_subnet            = length(module.vpc) > 0 ? module.vpc[0].load_balancer_subnet : var.vpc_id
     elastic_ip_allocation_id        = length(module.eip) > 0 ? module.eip[0].eip_allocation_id : var.kong_ingress_alloc_id

--- a/terraform/modules/aws/eks/main.tf
+++ b/terraform/modules/aws/eks/main.tf
@@ -279,6 +279,32 @@ resource "aws_iam_role" "flink_sa_iam_role" {
   var.additional_tags)
 }
 
+resource "aws_iam_role" "trino_sa_iam_role" {
+  name                = "${var.env}-${var.building_block}-${var.trino_sa_iam_role_name}"
+  assume_role_policy  = templatefile("${path.module}/oidc_assume_role_policy.json.tfpl", { OIDC_ARN = aws_iam_openid_connect_provider.eks_openid.arn, OIDC_URL = replace(aws_iam_openid_connect_provider.eks_openid.url, "https://", ""), NAMESPACE = "${var.trino_namespace}", SA_NAME = "${var.trino_namespace}-sa" })
+  managed_policy_arns = ["arn:aws:iam::aws:policy/AmazonS3FullAccess"]
+  depends_on          = [aws_iam_openid_connect_provider.eks_openid]
+  tags = merge(
+    {
+      Name = "${var.env}-${var.trino_sa_iam_role_name}"
+    },
+    local.common_tags,
+  var.additional_tags)
+}
+
+resource "aws_iam_role" "hms_sa_iam_role" {
+  name                = "${var.env}-${var.building_block}-${var.hms_sa_iam_role_name}"
+  assume_role_policy  = templatefile("${path.module}/oidc_assume_role_policy.json.tfpl", { OIDC_ARN = aws_iam_openid_connect_provider.eks_openid.arn, OIDC_URL = replace(aws_iam_openid_connect_provider.eks_openid.url, "https://", ""), NAMESPACE = "${var.hms_namespace}", SA_NAME = "${var.hms_namespace}-sa" })
+  managed_policy_arns = ["arn:aws:iam::aws:policy/AmazonS3FullAccess"]
+  depends_on          = [aws_iam_openid_connect_provider.eks_openid]
+  tags = merge(
+    {
+      Name = "${var.env}-${var.hms_sa_iam_role_name}"
+    },
+    local.common_tags,
+  var.additional_tags)
+}
+
 resource "aws_iam_role" "druid_raw_sa_iam_role" {
   name                = "${var.env}-${var.building_block}-${var.druid_raw_sa_iam_role_name}"
   assume_role_policy  = templatefile("${path.module}/oidc_assume_role_policy.json.tfpl", { OIDC_ARN = aws_iam_openid_connect_provider.eks_openid.arn, OIDC_URL = replace(aws_iam_openid_connect_provider.eks_openid.url, "https://", ""), NAMESPACE = "${var.druid_raw_namespace}", SA_NAME = "${var.druid_raw_namespace}-sa" })

--- a/terraform/modules/aws/eks/outputs.tf
+++ b/terraform/modules/aws/eks/outputs.tf
@@ -16,6 +16,14 @@ output "flink_sa_iam_role" {
   value = aws_iam_role.flink_sa_iam_role.arn
 }
 
+output "trino_sa_iam_role" {
+  value = aws_iam_role.trino_sa_iam_role.arn
+}
+
+output "hms_sa_iam_role" {
+  value = aws_iam_role.hms_sa_iam_role.arn
+}
+
 output "druid_raw_sa_iam_role" {
   value = aws_iam_role.druid_raw_sa_iam_role.arn
 }

--- a/terraform/modules/aws/eks/variables.tf
+++ b/terraform/modules/aws/eks/variables.tf
@@ -178,6 +178,30 @@ variable "flink_namespace" {
   default     = "flink"
 }
 
+variable "trino_sa_iam_role_name" {
+  type        = string
+  description = "IAM role name for trino service account."
+  default     = "trino-sa-iam-role"
+}
+
+variable "trino_namespace" {
+  type        = string
+  description = "Trino namespace."
+  default     = "trino"
+}
+
+variable "hms_sa_iam_role_name" {
+  type        = string
+  description = "IAM role name for hive metastore service account."
+  default     = "hms-sa-iam-role"
+}
+
+variable "hms_namespace" {
+  type        = string
+  description = "Hive metastore namespace."
+  default     = "hms"
+}
+
 variable "druid_raw_sa_iam_role_name" {
   type        = string
   description = "IAM role name for druid raw service account."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AWS IAM Roles for Service Accounts (IRSA) for Trino and Hive Metastore with OIDC trust and role provisioning.
  * Added/updated service account configuration so both components use dedicated ServiceAccounts with role annotations.
* **Bug Fixes**
  * Updated S3A configuration to use `fs.s3a.impl` and WebIdentity token credentials, removing static access/secret key wiring.
  * Fixed S3A implementation property usage and related metastore connector settings.
* **Updates**
  * HMS image default tag bumped to 1.0.5; HMS Docker base and Hadoop version updated.
  * Lakehouse-connector pods now honor either created ServiceAccounts or an explicitly provided ServiceAccount name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->