### PR TITLE
#fix: eks upgrade from 1.33 to 1.34

### DIFF
--- a/helmcharts/services/kube-prometheus-stack/values.yaml
+++ b/helmcharts/services/kube-prometheus-stack/values.yaml
@@ -10,7 +10,7 @@ nameOverride: ""
 ##
 namespaceOverride: ""
 
-## Provide a k8s version to auto dashboard import script example: kubeTargetVersionOverride: 1.33.0
+## Provide a k8s version to auto dashboard import script example: kubeTargetVersionOverride: 1.34.0
 ##
 kubeTargetVersionOverride: ""
 

--- a/terraform/modules/aws/eks/main.tf
+++ b/terraform/modules/aws/eks/main.tf
@@ -132,6 +132,7 @@ resource "aws_eks_node_group" "eks_nodes" {
   ami_type        = var.eks_node_group_ami_type
   instance_types  = var.eks_node_group_instance_type
   capacity_type   = var.eks_node_group_capacity_type
+  version         = var.eks_version
   # disk_size       = var.eks_node_disk_size
 
   tags = merge(

--- a/terraform/modules/aws/eks/variables.tf
+++ b/terraform/modules/aws/eks/variables.tf
@@ -89,19 +89,19 @@ variable "eks_addons" {
   default = [
     {
     name  = "kube-proxy"
-      version = "v1.34.6-eksbuild.13"
+    version = "v1.34.6-eksbuild.13"
     },
     {
     name  = "vpc-cni"
-      version = "v1.22.2-eksbuild.1"
+    version = "v1.22.2-eksbuild.1"
     },
     {
     name  = "coredns"
-      version = "v1.13.2-eksbuild.11"
+    version = "v1.13.2-eksbuild.11"
     },
     {
     name  = "aws-ebs-csi-driver"
-      version = "v1.46.0-eksbuild.1"
+    version = "v1.46.0-eksbuild.1"
     }
   ]
 }

--- a/terraform/modules/aws/eks/variables.tf
+++ b/terraform/modules/aws/eks/variables.tf
@@ -77,7 +77,7 @@ variable "eks_node_group_scaling_config" {
 variable "eks_version" {
   type        = string
   description = "EKS version."
-  default     = "1.33"
+  default     = "1.34"
 }
 
 variable "eks_addons" {
@@ -89,19 +89,19 @@ variable "eks_addons" {
   default = [
     {
     name  = "kube-proxy"
-    version = "v1.33.0-eksbuild.2"
+      version = "v1.34.6-eksbuild.13"
     },
     {
     name  = "vpc-cni"
-    version = "v1.20.0-eksbuild.1"
+      version = "v1.22.2-eksbuild.1"
     },
     {
     name  = "coredns"
-    version = "v1.12.2-eksbuild.4"
+      version = "v1.13.2-eksbuild.11"
     },
     {
     name  = "aws-ebs-csi-driver"
-    version = "v1.46.0-eksbuild.1"
+      version = "v1.46.0-eksbuild.1"
     }
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Kubernetes and EKS defaults to newer supported versions.
  * Aligned node group version settings with the cluster version for more consistent deployments.

* **Style**
  * Refreshed an inline version example in the Helm values comments to reflect Kubernetes 1.34.0.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->